### PR TITLE
fix: ページタイトルを「社内図書管理システム」に変更

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>frontend</title>
+    <title>社内図書管理システム</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
Issue #43 で報告されたページタイトルの修正を行いました。

## 変更内容
- `frontend/index.html` のタイトルを "frontend" から "社内図書管理システム" に変更

Closes #43

Generated with [Claude Code](https://claude.ai/code)