### PR TITLE
fix: resolve Heroku deployment failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN npm run build
 FROM python:3.12-slim as backend-builder
 WORKDIR /app/backend
 RUN pip install poetry
-COPY backend/pyproject.toml backend/poetry.lock ./
+COPY backend/pyproject.toml ./
 RUN poetry config virtualenvs.create false && \
     poetry install --without dev --no-root --no-interaction --no-ansi
 


### PR DESCRIPTION
Fixes the Heroku deployment issue that occurred after merging PR #46.

## Problem
The Dockerfile was trying to copy `backend/poetry.lock` which no longer exists (intentionally deleted to fix CI/CD issues), causing Heroku builds to fail.

## Solution
Removed `poetry.lock` from the COPY command in the Dockerfile. Poetry will generate a fresh lock file during the Docker build process.

## Changes
- Modified `Dockerfile` line 15: `COPY backend/poetry.lock` → `COPY backend/poetry.toml` only

Generated with [Claude Code](https://claude.ai/code)